### PR TITLE
Mock interfaces default methods.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,3 +9,8 @@ allprojects {
     group = "org.kodein.mock"
     version = "1.2.0"
 }
+
+// Support M1 (patch for now due to KotlinJS relying on a version 14 not available for arm64)
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
+}

--- a/mockmp-processor/src/main/kotlin/org/kodein/mock/ksp/MocKMPProcessor.kt
+++ b/mockmp-processor/src/main/kotlin/org/kodein/mock/ksp/MocKMPProcessor.kt
@@ -198,7 +198,9 @@ public class MocKMPProcessor(
                     gCls.addProperty(gProp.build())
                 }
             vItf.getAllFunctions()
-                .filter { it.isAbstract }
+                // Methods [equals] & [hashCode] are used when we add mocks in collections like Set/Map.
+                // toString() is probably not something we want to mock/verify and is the 3rd [Any] method.
+                .filter { it.simpleName.asString() !in listOf("equals", "hashCode", "toString") }
                 .forEach { vFun ->
                     val gFun = FunSpec.builder(vFun.simpleName.asString())
                         .addModifiers(KModifier.OVERRIDE)
@@ -206,7 +208,7 @@ public class MocKMPProcessor(
                     vFun.typeParameters.forEach { vParam ->
                         gFun.addTypeVariable(vParam.toTypeVariableName(typeParamResolver))
                     }
-                    gFun.addModifiers((vFun.modifiers - Modifier.ABSTRACT).mapNotNull { it.toKModifier() })
+                    gFun.addModifiers((vFun.modifiers - Modifier.ABSTRACT - Modifier.OPEN).mapNotNull { it.toKModifier() })
                     gFun.returns(vFun.returnType!!.toTypeName(typeParamResolver))
                     vFun.parameters.forEach { vParam ->
                         gFun.addParameter(vParam.name!!.asString(), vParam.type.toTypeName(typeParamResolver))

--- a/tests/src/commonMain/kotlin/foo/Foo.kt
+++ b/tests/src/commonMain/kotlin/foo/Foo.kt
@@ -20,5 +20,5 @@ interface Bar : Foo<Bar> {
     fun doAll(string: String, int: Int, data: Data)
     suspend fun newData(): Data
     fun callback(cb: (String) -> Int)
-    fun <T: Comparable<T>> order(c: Iterable<T>) : List<T>
+    fun <T : Comparable<T>> order(c: Iterable<T>): List<T>
 }

--- a/tests/src/commonTest/kotlin/tests/VerificationTests.kt
+++ b/tests/src/commonTest/kotlin/tests/VerificationTests.kt
@@ -209,4 +209,29 @@ class VerificationTests {
         assertEquals(42, foo.defaultT)
         mocker.verifyWithSuspend { foo.defaultT }
     }
+
+    @Test
+    fun testDefaultMethodOnInterface_notCalled() {
+        val bar = MockBar(mocker)
+        var throwable: Throwable? = null
+        try {
+            mocker.verify { bar.doNothing() }
+        } catch (ae: AssertionError) {
+            // expecting an AssertionError here as the mock has never been called
+            throwable = ae
+        }
+        assertEquals("Expected a call to MockBar.doNothing() but call list was empty", throwable?.message)
+    }
+
+    @Test
+    fun testDefaultMethodOnInterface_called() {
+        val bar = MockBar(mocker)
+        var throwable: Throwable? = null
+        try {
+            bar.doNothing()
+        } catch (me: Mocker.MockingException) {
+            throwable = me
+        }
+        assertEquals("MockBar.doNothing() has not been mocked", throwable?.message)
+    }
 }


### PR DESCRIPTION
Related to https://github.com/Kodein-Framework/MocKMP/issues/5

`equals` and `hashCode` are actually used in the MocKMP code itself, so if we want to support them, we'll need a rework to ignore those calls.

M1 support is optional, like the filtering of `toString`.