### PR TITLE
Fix JVM interface instanciation by trying to find a generated Mock for the interface

### DIFF
--- a/tests/src/commonMain/kotlin/foo/Foo.kt
+++ b/tests/src/commonMain/kotlin/foo/Foo.kt
@@ -11,6 +11,7 @@ interface Foo<out T : Any> {
     fun newString(): String
     fun newT(): T
     val defaultT: T
+    fun consume(bar: Bar)
 }
 
 interface Bar : Foo<Bar> {

--- a/tests/src/commonTest/kotlin/tests/VerificationTests.kt
+++ b/tests/src/commonTest/kotlin/tests/VerificationTests.kt
@@ -209,4 +209,16 @@ class VerificationTests {
         assertEquals(42, foo.defaultT)
         mocker.verifyWithSuspend { foo.defaultT }
     }
+
+    @Test
+    fun testIsAnyOnInterface() {
+        val foo = MockFoo<Bar>(mocker)
+        mocker.every { foo.consume(isAny()) } returns Unit
+
+        foo.consume(MockBar(mocker))
+
+        mocker.verify {
+            foo.consume(isAny())
+        }
+    }
 }


### PR DESCRIPTION
A patch for https://github.com/Kodein-Framework/MocKMP/issues/7

I presume we could do better by checking at build time that the configuration isn't good. This approach is only a guessing that could work or a better error message.